### PR TITLE
Update board member responsibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ To help RailsBridge grow geographically and organizationally by creating structu
 ## Responsibilities of Board Members
 
 * Serve on the board for a 2 year term
-* Attend monthly board meetings 
+* Attend monthly board meetings
+  * Board members need to attend 3/4 of the board meetings to remain on the board. Attendance will be reviewed on a quarterly basis.
 * Serve on at least one RailsBridge team or committee (i.e. finance, communications, geographic expansion, operations)
-* Board members should expect to do 10-15 hours of RailsBridge work per month, depending on the board member’s responsibilities
+* Board members should expect to do about 10 hours of RailsBridge work per month, depending on the board member’s responsibilities
 * Recruit new committee and board members
 * Attend two RailsBridge workshops per year to stay connected to the RailsBridge community
 


### PR DESCRIPTION
Two changes:

* Change the time expectation from 10-15 hours per month to 10 hours per month. I've been doing time tracking for my various volunteer gigs, and I put in about 12 hours (plus some unaccounted Slack and email time) in February. I think 15 hours/month is too high to set as an expectation for board members. I think 10 makes more sense — 3 hours of board meetings per month, plus 7 hours of email / committee work. 
* Outline the expectation that board members will attend 3/4 regularly scheduled meetings to remain on the board. I'm not married to this percentage, but I think we need to have a starting place for an attendance requirement and 3/4 seems reasonable to me.